### PR TITLE
Updating rbac to auto route config

### DIFF
--- a/config/rbac.yaml
+++ b/config/rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cpx
 rules:
 - apiGroups: [""]
-  resources: ["services", "endpoints", "ingresses", "pods", "secrets"]
+  resources: ["services", "endpoints", "ingresses", "pods", "secrets", "nodes"]
   verbs: ["*"]
 - apiGroups: ["extensions"]
   resources: ["ingresses", "ingresses/status"]
@@ -24,4 +24,3 @@ subjects:
 - kind: ServiceAccount
   name: cpx
   namespace: tier-2-adc
-


### PR DESCRIPTION
For auto route configuration, CIC should be provided with permissions to listen to events of nodes resource type